### PR TITLE
Fix fallback behavior

### DIFF
--- a/lib/paperclip-globalize3.rb
+++ b/lib/paperclip-globalize3.rb
@@ -4,13 +4,26 @@ require "paperclip/globalize3/attachment"
 require "globalize"
 require "paperclip"
 
-Paperclip.interpolates(:locale) { |attachment, _|
-  if attachment.instance.send("#{attachment.name}_file_name").respond_to?(:translation_metadata)
-    attachment.instance.send("#{attachment.name}_file_name").translation_metadata[:locale].to_s
-  else
-    Globalize.locale.to_s
-  end
-}
+# Paperclip locale interpolation: if locale fallbacks are used, we need to determine & use the fallback locale
+Paperclip.interpolates(:locale) do |attachment, _style_name|
+  record = attachment.instance
+  file_name_attr = "#{attachment.name}_file_name"
+  attachment_locale =
+    if record.respond_to?(:translation) && record.translated?(file_name_attr)
+      # determine via metadata if activated (I18n::Backend::Simple.include(I18n::Backend::Metadata))
+      if record.send(file_name_attr).respond_to?(:translation_metadata)
+        record.send(file_name_attr).translation_metadata[:locale]
+      else # determine via globalize fallback configuration
+        (record.globalize_fallbacks(Globalize.locale) & record.translated_locales).first # (nil if record is new)
+      end
+    else
+      Rails.logger.warn(
+        "WARN You have used :locale in a paperclip url/path for an untranslated model (in #{record.class.to_s})."
+      )
+      nil
+    end
+  (attachment_locale || Globalize.locale).to_s
+end
 
 unless Paperclip::Attachment.instance_methods.include?(:assign_attributes)
   Paperclip::Attachment.send(:include, Paperclip::Globalize3::Attachment::Compatibility::Paperclip41)

--- a/spec/attachment_helper_spec.rb
+++ b/spec/attachment_helper_spec.rb
@@ -24,7 +24,7 @@ describe 'Paperclip::Globalize3::Attachment' do
 
   context 'with translations' do
 
-    it 'should save different images for different locales' do
+    it 'saves different images for different locales' do
       p = Post.create
       Globalize.with_locale(:en) do
         p.image_file_name.should be_nil
@@ -46,7 +46,7 @@ describe 'Paperclip::Globalize3::Attachment' do
       Post.translation_class.count.should == 2
     end
 
-    it 'should only overwrite the image file for the current locale on re-assign' do
+    it 'only overwrites the image file for the current locale on re-assign' do
       p = Post.create
       path_en = Globalize.with_locale(:en) do
         p.update_attributes!(:image => test_image_file)
@@ -70,7 +70,7 @@ describe 'Paperclip::Globalize3::Attachment' do
       File.exist?(path_de).should be_true
     end
 
-    it 'should delete image files in all locales on destroy' do
+    it 'deletes image files in all locales on destroy' do
       p = Post.create
       path_en = Globalize.with_locale(:en) do
         p.update_attributes!(:image => test_image_file)
@@ -90,7 +90,7 @@ describe 'Paperclip::Globalize3::Attachment' do
 
     context 'with :only_process' do
 
-      it 'should only clear the provided style in the current locale on assign' do
+      it 'only clears the provided style in the current locale on assign' do
         p = OnlyProcessPost.create
         p.image.should_receive(:queue_some_for_delete).with(:thumb, :locales => :en)
         p.image.should_not_receive(:queue_all_for_delete)
@@ -106,7 +106,7 @@ describe 'Paperclip::Globalize3::Attachment' do
 
   context 'without translations' do
 
-    it 'should delete image files on destroy' do
+    it 'deletes image files on destroy' do
       p = Untranslated.create
       p.update_attributes!(:image => test_image_file)
       path = p.image.path


### PR DESCRIPTION
Gem now interpolates correct fallback locale when Globalize.fallbacks are set, instead of simply using the current Globalize.locale.

This new behavior caused trouble with the cleaning of attachment files, on assignment of a new one. Because of that all translated attachments that are not effected by the assignment of a new file are preserved.