### PR TITLE
Allow the use of Globalize 5.2

### DIFF
--- a/paperclip-globalize3.gemspec
+++ b/paperclip-globalize3.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.2.2'
 
   spec.add_dependency 'activerecord', ['>= 4.2', '< 5.2']
-  spec.add_dependency 'globalize', ['>= 5.0.0', '< 5.2.0']
+  spec.add_dependency 'globalize', ['>= 5.0.0', '< 5.3.0']
   spec.add_dependency 'paperclip', ['>= 4.2', '< 6.2.0']
 
   spec.add_development_dependency 'appraisal', '~> 2.2'


### PR DESCRIPTION
Relaxes the version constraint of Globalize to < 5.3.0 to allow use of Paperclip 5.2.x. Globalize follows semver so its not expected to be breaking within the 5.2.x releases.