### PR TITLE
Switch to globalize 5.3 to regain compatibility with Rails 4.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: ruby
 rvm:
-  - 2.2.10
-  - 2.3.8
-  - 2.4.5
+  - 2.4.6
+  - 2.5.5
+  - 2.6.3
 before_install:
   - gem uninstall -v '>= 2.0.1' -i $(rvm gemdir)@global -ax bundler || true
   - gem install bundler -v '1.16.6'

--- a/Appraisals
+++ b/Appraisals
@@ -3,37 +3,31 @@
 appraise 'rails-4.2-pc-4-2' do
   gem 'rails',      '~> 4.2.0'
   gem 'paperclip',  '~> 4.2.0'
-  gem 'globalize', git: 'https://github.com/globalize/globalize', branch: 'master', ref: '3fe2f93ab2'
 end
 
 appraise 'rails-4.2-pc-4-3' do
   gem 'rails',      '~> 4.2.0'
   gem 'paperclip',  '~> 4.3.0'
-  gem 'globalize', git: 'https://github.com/globalize/globalize', branch: 'master', ref: '3fe2f93ab2'
 end
 
 appraise 'rails-4.2-pc-5-0' do
   gem 'rails',      '~> 4.2.0'
   gem 'paperclip',  '~> 5.0.0'
-  gem 'globalize', git: 'https://github.com/globalize/globalize', branch: 'master', ref: '3fe2f93ab2'
 end
 
 appraise 'rails-4.2-pc-5-2' do
   gem 'rails',      '~> 4.2.0'
   gem 'paperclip',  '~> 5.2.0'
-  gem 'globalize', git: 'https://github.com/globalize/globalize', branch: 'master', ref: '3fe2f93ab2'
 end
 
 appraise 'rails-4.2-pc-6-0' do
   gem 'rails',      '~> 4.2.0'
   gem 'paperclip',  '~> 6.0.0'
-  gem 'globalize', git: 'https://github.com/globalize/globalize', branch: 'master', ref: '3fe2f93ab2'
 end
 
 appraise 'rails-4.2-pc-6-1' do
   gem 'rails',      '~> 4.2.0'
   gem 'paperclip',  '~> 6.1.0'
-  gem 'globalize', git: 'https://github.com/globalize/globalize', branch: 'master', ref: '3fe2f93ab2'
 end
 
 # Rails 5.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,13 @@
 # (unreleased)
 
+* Breaking changes 
+    * Drop support for ruby < 2.4.6
+    * Drop support for globalize < 5.3   
 * Bugfixes
     * (none)
 * Enhancements
-    * (none)
+    * Allow globalize 5.3
+      With globalize 5.3.0 paperclip-globalize3 is again compatible witj Rails 4.2 
 
 # 3.3.0 (2019-05-14)
 

--- a/README.md
+++ b/README.md
@@ -12,16 +12,10 @@ Note that this implementation patches some methods in the `Paperclip::Attachment
 ## Compatibility
 
 * paperclip 4.2 - 6.1
-* globalize 5.0 - 5.2
+* globalize 5.3
 * Rails 4.2/5.0/5.1
 
 For support of previous paperclip / globalize / rails versions please refer to the 2.x versions of this gem.
-
-### Important Note for Rails 4.2.x with globalize 5.2.0
-
-If you use Rails 4.2: There is a bug in globalize 5.2.0. Ensure you use globalize 5.2.1 or later after it gets released. Meanwhile, you should be able to use the following instead (which is one commit after the 5.2.0 release and includes the fix):
-
-    gem 'globalize', git: 'https://github.com/globalize/globalize', branch: 'master', ref: '3fe2f93ab2'
 
 ## Maintainance State of This Gem
 

--- a/gemfiles/rails_4.2_pc_4_2.gemfile
+++ b/gemfiles/rails_4.2_pc_4_2.gemfile
@@ -4,6 +4,5 @@ source 'https://rubygems.org'
 
 gem 'rails', '~> 4.2.0'
 gem 'paperclip', '~> 4.2.0'
-gem 'globalize', git: 'https://github.com/globalize/globalize', branch: 'master', ref: '3fe2f93ab2'
 
 gemspec path: '../'

--- a/gemfiles/rails_4.2_pc_4_3.gemfile
+++ b/gemfiles/rails_4.2_pc_4_3.gemfile
@@ -4,6 +4,5 @@ source 'https://rubygems.org'
 
 gem 'rails', '~> 4.2.0'
 gem 'paperclip', '~> 4.3.0'
-gem 'globalize', git: 'https://github.com/globalize/globalize', branch: 'master', ref: '3fe2f93ab2'
 
 gemspec path: '../'

--- a/gemfiles/rails_4.2_pc_5_0.gemfile
+++ b/gemfiles/rails_4.2_pc_5_0.gemfile
@@ -4,6 +4,5 @@ source 'https://rubygems.org'
 
 gem 'rails', '~> 4.2.0'
 gem 'paperclip', '~> 5.0.0'
-gem 'globalize', git: 'https://github.com/globalize/globalize', branch: 'master', ref: '3fe2f93ab2'
 
 gemspec path: '../'

--- a/gemfiles/rails_4.2_pc_5_2.gemfile
+++ b/gemfiles/rails_4.2_pc_5_2.gemfile
@@ -4,6 +4,5 @@ source 'https://rubygems.org'
 
 gem 'rails', '~> 4.2.0'
 gem 'paperclip', '~> 5.2.0'
-gem 'globalize', git: 'https://github.com/globalize/globalize', branch: 'master', ref: '3fe2f93ab2'
 
 gemspec path: '../'

--- a/gemfiles/rails_4.2_pc_6_0.gemfile
+++ b/gemfiles/rails_4.2_pc_6_0.gemfile
@@ -4,6 +4,5 @@ source 'https://rubygems.org'
 
 gem 'rails', '~> 4.2.0'
 gem 'paperclip', '~> 6.0.0'
-gem 'globalize', git: 'https://github.com/globalize/globalize', branch: 'master', ref: '3fe2f93ab2'
 
 gemspec path: '../'

--- a/gemfiles/rails_4.2_pc_6_1.gemfile
+++ b/gemfiles/rails_4.2_pc_6_1.gemfile
@@ -4,6 +4,5 @@ source 'https://rubygems.org'
 
 gem 'rails', '~> 4.2.0'
 gem 'paperclip', '~> 6.1.0'
-gem 'globalize', git: 'https://github.com/globalize/globalize', branch: 'master', ref: '3fe2f93ab2'
 
 gemspec path: '../'

--- a/paperclip-globalize3.gemspec
+++ b/paperclip-globalize3.gemspec
@@ -18,10 +18,10 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 2.2.2'
+  spec.required_ruby_version = '>= 2.4.6'
 
   spec.add_dependency 'activerecord', ['>= 4.2', '< 5.2']
-  spec.add_dependency 'globalize', ['>= 5.0.0', '< 5.3.0']
+  spec.add_dependency 'globalize', ['>= 5.3.0', '< 5.4.0']
   spec.add_dependency 'paperclip', ['>= 4.2', '< 6.2.0']
 
   spec.add_development_dependency 'appraisal', '~> 2.2'


### PR DESCRIPTION
* Dropped Support for Ruby < 2.4.5 to comply with minimum requirements of globalize
* Adjusted travis build matrix to include modern rubies (2.5, 2.6) and removed 2.2 and 2.3 which are EOL
* Adjusted README to include new compatibility notes