### PR TITLE
Fix sending styles to Paperclip

### DIFF
--- a/lib/paperclip/globalize3/attachment.rb
+++ b/lib/paperclip/globalize3/attachment.rb
@@ -57,7 +57,7 @@ module Paperclip
         options = args.extract_options!
         styles  = args
         with_locales_if_translated(options[:locales]) do
-          super(styles)
+          super(*styles)
         end
       end
 


### PR DESCRIPTION
or we get `[[:style1, :style2]]` instead of `[:style1, :style2]`